### PR TITLE
Fix ESLint workflow permissions and SARIF upload conditions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   lint:
     name: Run ESLint
@@ -36,6 +40,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload ESLint results
+        if: github.event_name == 'push' # ✅ only upload on push, not PRs from forks
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: eslint-results.sarif


### PR DESCRIPTION
This update fixes the ESLint GitHub Actions workflow to prevent SARIF upload failures caused by insufficient token permissions and forked pull requests.

- Added explicit workflow permissions:
  ```yaml
  permissions:
    contents: read
    security-events: write
